### PR TITLE
make arc mode non-collapsible and add optional Create folder button

### DIFF
--- a/advanced-tab-groups.uc.js
+++ b/advanced-tab-groups.uc.js
@@ -869,15 +869,30 @@ class AdvancedTabGroups {
     });
   }
 
+  isArcMode() {
+    try {
+      return Services.prefs.getBoolPref("browser.tabs.groups.arc-style", false) ||
+        Services.prefs.getBoolPref("tab.groups.fill-folders", false) ||
+        Services.prefs.getBoolPref("tab.groups.theme-folders", false);
+    } catch { return false; }
+  }
+
   // Set up observer to track collapsed state changes
   setupGroupCollapsedObserver(group) {
     if (group._collapsedObserverAdded) return;
     group._collapsedObserverAdded = true;
 
+    if (this.isArcMode() && group.hasAttribute("collapsed")) {
+      try { group.removeAttribute("collapsed"); } catch {}
+    }
+
     const observer = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
         if (mutation.type === "attributes" && mutation.attributeName === "collapsed") {
-          // Save the collapsed state when it changes
+          if (this.isArcMode() && group.hasAttribute("collapsed")) {
+            try { group.removeAttribute("collapsed"); } catch {}
+            return;
+          }
           this.saveGroupCollapsedState(group.id, group.hasAttribute("collapsed"));
         }
       });
@@ -2179,12 +2194,14 @@ class AdvancedTabGroups {
   // Apply saved collapsed states to tab groups
   applySavedCollapsedStates() {
     try {
+      if (this.isArcMode()) return;
       const states = this.savedCollapsedStates;
       Object.entries(states).forEach(([groupId, isCollapsed]) => {
         if (isCollapsed) {
           // Use waitForElm to handle groups that might not be ready yet
           this.waitForElm(`tab-group[id="${groupId}"]`).then(group => {
             if (group && !group.hasAttribute("split-view-group")) {
+              if (this.isArcMode()) { group.removeAttribute("collapsed"); return; }
               group.setAttribute("collapsed", "true");
               console.log(`[AdvancedTabGroups] Applied collapsed state to group ${groupId}`);
             }

--- a/advanced-tab-groups.uc.js
+++ b/advanced-tab-groups.uc.js
@@ -755,7 +755,7 @@ class AdvancedTabGroups {
     grain.className = "grain";
     tabContainer.appendChild(grain);
 
-    // Create and inject the icon container and close button
+    // Create and inject the icon container and buttons
     const groupDomFrag = window.MozXULElement.parseXULToFragment(`
       <div class="tab-group-icon-container">
         <div class="tab-group-icon">
@@ -763,15 +763,24 @@ class AdvancedTabGroups {
         </div>
         <image class="group-marker" role="button" keyNav="false" tooltiptext="Toggle Group"/>
       </div>
+      <image class="tab-group-folder-button" role="button" keyNav="false" tooltiptext="Create folder"/>
       <image class="tab-close-button close-icon" role="button" keyNav="false" tooltiptext="Close Group"/>
     `);
     const iconContainer = groupDomFrag.children[0];
-    const closeButton = groupDomFrag.children[1];
+    const folderButton = groupDomFrag.children[1];
+    const closeButton = groupDomFrag.children[2];
 
     // Insert the icon container at the beginning of the label container
     labelContainer.insertBefore(iconContainer, labelContainer.firstChild);
-    // Add the close button to the label container
+    // Add the folder and close buttons to the label container
+    labelContainer.appendChild(folderButton);
     labelContainer.appendChild(closeButton);
+
+    folderButton.addEventListener("click", (event) => {
+      event.stopPropagation();
+      event.preventDefault();
+      try { this.convertGroupToFolder(group); } catch (e) { console.error("[AdvancedTabGroups] Error converting to folder:", e); }
+    });
 
     // Add click event listener
     closeButton.addEventListener("click", (event) => {

--- a/preferences.json
+++ b/preferences.json
@@ -16,6 +16,12 @@
     "label": "Apply Arc-like group styling"
   },
   {
+    "property": "browser.tabs.groups.show-folder-button",
+    "type": "checkbox",
+    "label": "Show Create folder button on tab groups",
+    "default": "true"
+  },
+  {
     "property": "browser.tabs.groups.allow-emojis",
     "type": "checkbox",
     "label": "Allow emojis as icons for tab groups"

--- a/userChrome.css
+++ b/userChrome.css
@@ -31,13 +31,24 @@ tab-group:not([split-view-group]) {
     align-items: center !important;
     justify-content: flex-start !important;
 
-    .tab-close-button {
+    .tab-close-button, .tab-group-folder-button {
       display: none !important;
+    }
+
+    .tab-group-folder-button {
+      list-style-image: url("chrome://browser/skin/zen-icons/folder.svg") !important;
+      -moz-context-properties: fill, fill-opacity !important;
+      fill: currentColor !important;
+      width: 16px !important;
+      height: 16px !important;
+      padding: 2px !important;
+      border-radius: var(--border-radius-small, 4px) !important;
+      margin-inline-start: 2px !important;
     }
 
     &:hover {
       background-color: var(--tab-hover-background-color) !important;
-      .tab-close-button {
+      .tab-close-button, .tab-group-folder-button {
         -moz-window-dragging: no-drag !important;
         visibility: visible !important;
         display: flex !important;
@@ -220,8 +231,12 @@ tab-group:not([split-view-group]) {
         }
       }
 
-      .tab-close-button {
+      .tab-close-button, .tab-group-folder-button {
         display: none !important;
+      }
+
+      &:hover .tab-close-button, &:hover .tab-group-folder-button {
+        display: flex !important;
       }
     }
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -41,9 +41,12 @@ tab-group:not([split-view-group]) {
       fill: currentColor !important;
       width: 16px !important;
       height: 16px !important;
-      padding: 2px !important;
+      padding: 4px !important;
       border-radius: var(--border-radius-small, 4px) !important;
-      margin-inline-start: 2px !important;
+      margin-inline: 6px 2px !important;
+    }
+    .tab-group-folder-button:hover {
+      background-color: color-mix(in srgb, currentColor 12%, transparent) !important;
     }
     @media not (-moz-pref("browser.tabs.groups.show-folder-button")) {
       .tab-group-folder-button {

--- a/userChrome.css
+++ b/userChrome.css
@@ -31,11 +31,11 @@ tab-group:not([split-view-group]) {
     align-items: center !important;
     justify-content: flex-start !important;
 
-    .tab-close-button, .tab-group-folder-button {
+    .tab-close-button {
       display: none !important;
     }
-
     .tab-group-folder-button {
+      display: none !important;
       list-style-image: url("chrome://browser/skin/zen-icons/folder.svg") !important;
       -moz-context-properties: fill, fill-opacity !important;
       fill: currentColor !important;
@@ -45,10 +45,22 @@ tab-group:not([split-view-group]) {
       border-radius: var(--border-radius-small, 4px) !important;
       margin-inline-start: 2px !important;
     }
+    @media not (-moz-pref("browser.tabs.groups.show-folder-button")) {
+      .tab-group-folder-button {
+        display: none !important;
+      }
+    }
 
     &:hover {
       background-color: var(--tab-hover-background-color) !important;
-      .tab-close-button, .tab-group-folder-button {
+      .tab-close-button {
+        -moz-window-dragging: no-drag !important;
+        visibility: visible !important;
+        display: flex !important;
+      }
+    }
+    @media (-moz-pref("browser.tabs.groups.show-folder-button")) {
+      &:hover .tab-group-folder-button {
         -moz-window-dragging: no-drag !important;
         visibility: visible !important;
         display: flex !important;
@@ -231,12 +243,19 @@ tab-group:not([split-view-group]) {
         }
       }
 
-      .tab-close-button, .tab-group-folder-button {
+      .tab-close-button {
         display: none !important;
       }
-
-      &:hover .tab-close-button, &:hover .tab-group-folder-button {
+      .tab-group-folder-button {
+        display: none !important;
+      }
+      &:hover .tab-close-button {
         display: flex !important;
+      }
+      @media (-moz-pref("browser.tabs.groups.show-folder-button")) {
+        &:hover .tab-group-folder-button {
+          display: flex !important;
+        }
       }
     }
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -230,6 +230,9 @@ tab-group:not([split-view-group]) {
       &::after {
         content: none;
       }
+      tab {
+        transition: none !important;
+      }
     }
 
     &[collapsed] {
@@ -237,8 +240,12 @@ tab-group:not([split-view-group]) {
         tab:not([selected]) {
           max-height: 40px !important;
           opacity: 100% !important;
+          transition: none !important;
         }
       }
     }
+  }
+  tab-group[collapsed] tab[aria-hidden="true"] {
+    transition: none !important;
   }
 }

--- a/userChrome.css
+++ b/userChrome.css
@@ -39,11 +39,11 @@ tab-group:not([split-view-group]) {
       list-style-image: url("chrome://browser/skin/zen-icons/folder.svg") !important;
       -moz-context-properties: fill, fill-opacity !important;
       fill: currentColor !important;
-      width: 16px !important;
-      height: 16px !important;
-      padding: 4px !important;
+      width: 20px !important;
+      height: 20px !important;
+      padding: 2px !important;
       border-radius: var(--border-radius-small, 4px) !important;
-      margin-inline: 6px 2px !important;
+      margin-inline: 4px 2px !important;
     }
     .tab-group-folder-button:hover {
       background-color: color-mix(in srgb, currentColor 12%, transparent) !important;


### PR DESCRIPTION
Follow-up to #145, addresses arc mode review:
- arc mode is now fundamentally non-collapsible (observer removes collapsed, saved state not restored, CSS transition:none and aria-hidden handled)
- add Create folder button (group → folder) on hover, toggleable via browser.tabs.groups.show-folder-button